### PR TITLE
로직 리펙터링

### DIFF
--- a/src/main/kotlin/com/iplease/server/ip/manage/domain/assign/handler/IpAssignedEventHandler.kt
+++ b/src/main/kotlin/com/iplease/server/ip/manage/domain/assign/handler/IpAssignedEventHandler.kt
@@ -1,18 +1,6 @@
 package com.iplease.server.ip.manage.domain.assign.handler
 
 import com.iplease.server.ip.manage.global.common.data.dto.AssignedIpDto
-import reactor.core.publisher.Mono
+import com.iplease.server.ip.manage.global.common.handler.EventHandler
 
-interface IpAssignedEventHandler {
-    fun handle(dto: AssignedIpDto) {
-        onStart(dto)
-            .doOnError{ onError(dto, it) }
-            .doOnSuccess { onComplete(dto, it) }
-            .onErrorReturn(dto)
-            .block()
-    }
-
-    fun onStart(dto: AssignedIpDto): Mono<AssignedIpDto>
-    fun onError(dto: AssignedIpDto, error: Throwable)
-    fun onComplete(request: AssignedIpDto, response: AssignedIpDto)
-}
+interface IpAssignedEventHandler: EventHandler<AssignedIpDto>

--- a/src/main/kotlin/com/iplease/server/ip/manage/domain/assign/handler/IpAssignedEventHandler.kt
+++ b/src/main/kotlin/com/iplease/server/ip/manage/domain/assign/handler/IpAssignedEventHandler.kt
@@ -3,4 +3,4 @@ package com.iplease.server.ip.manage.domain.assign.handler
 import com.iplease.server.ip.manage.global.common.data.dto.AssignedIpDto
 import com.iplease.server.ip.manage.global.common.handler.EventHandler
 
-interface IpAssignedEventHandler: EventHandler<AssignedIpDto>
+interface IpAssignedEventHandler: EventHandler<AssignedIpDto, AssignedIpDto>

--- a/src/main/kotlin/com/iplease/server/ip/manage/domain/assign/handler/IpAssignedEventHandler.kt
+++ b/src/main/kotlin/com/iplease/server/ip/manage/domain/assign/handler/IpAssignedEventHandler.kt
@@ -1,7 +1,18 @@
 package com.iplease.server.ip.manage.domain.assign.handler
 
 import com.iplease.server.ip.manage.global.common.data.dto.AssignedIpDto
+import reactor.core.publisher.Mono
 
 interface IpAssignedEventHandler {
-    fun handle(dto: AssignedIpDto)
+    fun handle(dto: AssignedIpDto) {
+        onStart(dto)
+            .doOnError{ onError(dto, it) }
+            .doOnSuccess { onComplete(dto, it) }
+            .onErrorReturn(dto)
+            .block()
+    }
+
+    fun onStart(dto: AssignedIpDto): Mono<AssignedIpDto>
+    fun onError(dto: AssignedIpDto, error: Throwable)
+    fun onComplete(request: AssignedIpDto, response: AssignedIpDto)
 }

--- a/src/main/kotlin/com/iplease/server/ip/manage/domain/assign/listener/IpAssignedEventListener.kt
+++ b/src/main/kotlin/com/iplease/server/ip/manage/domain/assign/listener/IpAssignedEventListener.kt
@@ -13,6 +13,7 @@ import com.iplease.server.ip.manage.infra.event.data.type.Event
 import com.iplease.server.ip.manage.infra.event.service.EventPublishService
 import org.springframework.amqp.core.Message
 import org.springframework.stereotype.Component
+import reactor.kotlin.core.publisher.toMono
 
 @Component
 class IpAssignedEventListener(
@@ -24,19 +25,18 @@ class IpAssignedEventListener(
 
     override fun handle(message: Message) {
         if(message.messageProperties.receivedRoutingKey != Event.IP_ASSIGNED.routingKey) return
-        runCatching {
-            ObjectMapper()
-                .registerModule(KotlinModule())
-                .registerModule(JavaTimeModule())
-                .readValue(message.body, IpAssignedEvent::class.java)
-        }.onFailure {
-            eventPublishService.publish(
-                Error.WRONG_PAYLOAD.routingKey,
-                WrongPayloadError(Event.IP_ASSIGNED, message.body.toString())
-            )
-        }.onSuccess {
-            it.toDto()
-            .let (ipAssignedEventHandler::handle)
-        }
+        ObjectMapper()
+            .registerModule(KotlinModule())
+            .registerModule(JavaTimeModule())
+            .toMono()
+            .map{ it.readValue(message.body, IpAssignedEvent::class.java) }
+            .doOnError{
+                eventPublishService.publish(
+                    Error.WRONG_PAYLOAD.routingKey,
+                    WrongPayloadError(Event.IP_ASSIGNED, message.body.toString())
+                )
+            }.map{ it.toDto() }
+            .flatMap { ipAssignedEventHandler.handle(it) }
+            .block()
     }
 }

--- a/src/main/kotlin/com/iplease/server/ip/manage/domain/assign/listener/IpAssignedEventListener.kt
+++ b/src/main/kotlin/com/iplease/server/ip/manage/domain/assign/listener/IpAssignedEventListener.kt
@@ -30,13 +30,13 @@ class IpAssignedEventListener(
             .registerModule(JavaTimeModule())
             .toMono()
             .map{ it.readValue(message.body, IpAssignedEvent::class.java) }
-            .doOnError{
+            .onErrorContinue {_, _ ->
                 eventPublishService.publish(
                     Error.WRONG_PAYLOAD.routingKey,
                     WrongPayloadError(Event.IP_ASSIGNED, message.body.toString())
                 )
             }.map{ it.toDto() }
-            .flatMap { ipAssignedEventHandler.handle(it) }
+            .flatMap { ipAssignedEventHandler.handle(it, it) }
             .block()
     }
 }

--- a/src/main/kotlin/com/iplease/server/ip/manage/domain/release/handler/IpReleaseEventHandler.kt
+++ b/src/main/kotlin/com/iplease/server/ip/manage/domain/release/handler/IpReleaseEventHandler.kt
@@ -3,4 +3,4 @@ package com.iplease.server.ip.manage.domain.release.handler
 import com.iplease.server.ip.manage.global.common.data.dto.ReleasedIpDto
 import com.iplease.server.ip.manage.global.common.handler.EventHandler
 
-interface IpReleaseEventHandler: EventHandler<ReleasedIpDto>
+interface IpReleaseEventHandler: EventHandler<ReleasedIpDto, Unit>

--- a/src/main/kotlin/com/iplease/server/ip/manage/domain/release/handler/IpReleaseEventHandler.kt
+++ b/src/main/kotlin/com/iplease/server/ip/manage/domain/release/handler/IpReleaseEventHandler.kt
@@ -1,0 +1,6 @@
+package com.iplease.server.ip.manage.domain.release.handler
+
+import com.iplease.server.ip.manage.global.common.data.dto.ReleasedIpDto
+import com.iplease.server.ip.manage.global.common.handler.EventHandler
+
+interface IpReleaseEventHandler: EventHandler<ReleasedIpDto>

--- a/src/main/kotlin/com/iplease/server/ip/manage/domain/release/handler/IpReleaseEventHandlerImpl.kt
+++ b/src/main/kotlin/com/iplease/server/ip/manage/domain/release/handler/IpReleaseEventHandlerImpl.kt
@@ -1,0 +1,21 @@
+package com.iplease.server.ip.manage.domain.release.handler
+
+import com.iplease.server.ip.manage.domain.release.service.IpReleaseService
+import com.iplease.server.ip.manage.global.common.data.dto.ReleasedIpDto
+import com.iplease.server.ip.manage.infra.event.data.dto.IpReleasedError
+import com.iplease.server.ip.manage.infra.event.data.type.Error
+import com.iplease.server.ip.manage.infra.event.service.EventPublishService
+import org.springframework.stereotype.Component
+import reactor.kotlin.core.publisher.toMono
+
+@Component
+class IpReleaseEventHandlerImpl(
+    private val eventPublishService: EventPublishService,
+    private val ipReleaseService: IpReleaseService
+): IpReleaseEventHandler {
+    override fun onStart(dto: ReleasedIpDto) = dto.toMono().flatMap { ipReleaseService.release(it.assignedIpUuid) }
+    override fun onError(dto: ReleasedIpDto, error: Throwable) { eventPublishService.publish(Error.IP_RELEASED.routingKey, dto.error(error)) }
+    override fun onComplete(request: ReleasedIpDto, response: Unit) {}
+
+    private fun ReleasedIpDto.error(throwable: Throwable) = IpReleasedError(assignedIpUuid, issuerUuid, throwable)
+}

--- a/src/main/kotlin/com/iplease/server/ip/manage/domain/release/listener/IpReleasedEventListener.kt
+++ b/src/main/kotlin/com/iplease/server/ip/manage/domain/release/listener/IpReleasedEventListener.kt
@@ -28,13 +28,14 @@ class IpReleasedEventListener(
             .registerKotlinModule()
             .toMono()
             .map { it.readValue(message.body, IpReleasedEvent::class.java) }
-            .doOnError {
+            .onErrorContinue{_, _ ->
                 eventPublishService.publish(
                     Error.WRONG_PAYLOAD.routingKey,
                     WrongPayloadError(Event.IP_RELEASED, message.body.toString())
                 )
-            }.map { it.toDto()}
-            .flatMap { ipReleaseEventHandler.handle(it) }
+            }
+            .map { it.toDto()}
+            .flatMap { ipReleaseEventHandler.handle(it, Unit) }
             .block()
     }
 }

--- a/src/main/kotlin/com/iplease/server/ip/manage/domain/release/service/IpReleaseServiceImpl.kt
+++ b/src/main/kotlin/com/iplease/server/ip/manage/domain/release/service/IpReleaseServiceImpl.kt
@@ -2,9 +2,11 @@ package com.iplease.server.ip.manage.domain.release.service
 
 import com.iplease.server.ip.manage.domain.release.exception.UnknownAssignedIpException
 import com.iplease.server.ip.manage.global.common.repository.AssignedIpRepository
+import org.springframework.stereotype.Service
 import reactor.core.publisher.Mono
 import reactor.kotlin.core.publisher.toMono
 
+@Service
 class IpReleaseServiceImpl(
     private val ipReleaseRepository: AssignedIpRepository
 ): IpReleaseService {

--- a/src/main/kotlin/com/iplease/server/ip/manage/global/common/data/dto/ReleasedIpDto.kt
+++ b/src/main/kotlin/com/iplease/server/ip/manage/global/common/data/dto/ReleasedIpDto.kt
@@ -1,0 +1,3 @@
+package com.iplease.server.ip.manage.global.common.data.dto
+
+data class ReleasedIpDto(val assignedIpUuid: Long, val issuerUuid: Long)

--- a/src/main/kotlin/com/iplease/server/ip/manage/global/common/handler/EventHandler.kt
+++ b/src/main/kotlin/com/iplease/server/ip/manage/global/common/handler/EventHandler.kt
@@ -2,14 +2,14 @@ package com.iplease.server.ip.manage.global.common.handler
 
 import reactor.core.publisher.Mono
 
-interface EventHandler<T: Any> {
-    fun handle(dto: T): Mono<T> =
+interface EventHandler<T: Any, R: Any> {
+    fun handle(dto: T, onErrorReturn: R): Mono<R> =
         onStart(dto)
             .doOnError{ onError(dto, it) }
             .doOnSuccess { onComplete(dto, it) }
-            .onErrorReturn(dto)
+            .onErrorReturn(onErrorReturn)
 
-    fun onStart(dto: T): Mono<T>
+    fun onStart(dto: T): Mono<R>
     fun onError(dto: T, error: Throwable)
-    fun onComplete(request: T, response: T)
+    fun onComplete(request: T, response: R)
 }

--- a/src/main/kotlin/com/iplease/server/ip/manage/global/common/handler/EventHandler.kt
+++ b/src/main/kotlin/com/iplease/server/ip/manage/global/common/handler/EventHandler.kt
@@ -1,0 +1,15 @@
+package com.iplease.server.ip.manage.global.common.handler
+
+import reactor.core.publisher.Mono
+
+interface EventHandler<T: Any> {
+    fun handle(dto: T): Mono<T> =
+        onStart(dto)
+            .doOnError{ onError(dto, it) }
+            .doOnSuccess { onComplete(dto, it) }
+            .onErrorReturn(dto)
+
+    fun onStart(dto: T): Mono<T>
+    fun onError(dto: T, error: Throwable)
+    fun onComplete(request: T, response: T)
+}

--- a/src/main/kotlin/com/iplease/server/ip/manage/infra/event/data/dto/IpReleasedEvent.kt
+++ b/src/main/kotlin/com/iplease/server/ip/manage/infra/event/data/dto/IpReleasedEvent.kt
@@ -1,5 +1,9 @@
 package com.iplease.server.ip.manage.infra.event.data.dto
 
+import com.iplease.server.ip.manage.global.common.data.dto.ReleasedIpDto
+
 data class IpReleasedEvent(
     val assignedIpUuid: Long,
-    val issuerUuid: Long)
+    val issuerUuid: Long) {
+    fun toDto() = ReleasedIpDto(assignedIpUuid, issuerUuid)
+}

--- a/src/test/kotlin/com/iplease/server/ip/manage/domain/assign/listener/IpAssignedEventListenerTest.kt
+++ b/src/test/kotlin/com/iplease/server/ip/manage/domain/assign/listener/IpAssignedEventListenerTest.kt
@@ -79,10 +79,10 @@ class IpAssignedEventListenerTest {
         whenever(messageProperties.receivedRoutingKey).thenReturn(Event.IP_ASSIGNED.routingKey)
         whenever(message.messageProperties).thenReturn(messageProperties)
         whenever(message.body).thenReturn(eventStr.toByteArray())
-        whenever(ipAssignedEventHandler.handle(assignedIpDto)).thenReturn(assignedIpDto.toMono())
+        whenever(ipAssignedEventHandler.handle(eq(assignedIpDto.copy(uuid = 0)), any())).thenReturn(assignedIpDto.toMono())
 
         target.handle(message)
-        verify(ipAssignedEventHandler, times(1)).handle(assignedIpDto.copy(uuid = 0))
+        verify(ipAssignedEventHandler, times(1)).handle(eq(assignedIpDto.copy(uuid = 0)), any())
         verify(eventPublishService, never()).publish(any(), any())
     }
 
@@ -94,7 +94,7 @@ class IpAssignedEventListenerTest {
         whenever(message.body).thenReturn(eventStr.toByteArray())
 
         target.handle(message)
-        verify(ipAssignedEventHandler, never()).handle(any())
+        verify(ipAssignedEventHandler, never()).handle(eq(assignedIpDto), any())
         verify(eventPublishService, times(1)).publish(
             Error.WRONG_PAYLOAD.routingKey,
             WrongPayloadError(Event.IP_ASSIGNED, message.body.toString())

--- a/src/test/kotlin/com/iplease/server/ip/manage/domain/assign/listener/IpAssignedEventListenerTest.kt
+++ b/src/test/kotlin/com/iplease/server/ip/manage/domain/assign/listener/IpAssignedEventListenerTest.kt
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.kotlin.*
 import org.springframework.amqp.core.Message
 import org.springframework.amqp.core.MessageProperties
+import reactor.kotlin.core.publisher.toMono
 import java.time.LocalDate
 import kotlin.properties.Delegates
 import kotlin.random.Random
@@ -78,6 +79,7 @@ class IpAssignedEventListenerTest {
         whenever(messageProperties.receivedRoutingKey).thenReturn(Event.IP_ASSIGNED.routingKey)
         whenever(message.messageProperties).thenReturn(messageProperties)
         whenever(message.body).thenReturn(eventStr.toByteArray())
+        whenever(ipAssignedEventHandler.handle(assignedIpDto)).thenReturn(assignedIpDto.toMono())
 
         target.handle(message)
         verify(ipAssignedEventHandler, times(1)).handle(assignedIpDto.copy(uuid = 0))

--- a/src/test/kotlin/com/iplease/server/ip/manage/domain/release/listener/IpReleasedEventListenerTest.kt
+++ b/src/test/kotlin/com/iplease/server/ip/manage/domain/release/listener/IpReleasedEventListenerTest.kt
@@ -61,10 +61,10 @@ class IpReleasedEventListenerTest {
         whenever(messageProperties.receivedRoutingKey).thenReturn(Event.IP_RELEASED.routingKey)
         whenever(message.messageProperties).thenReturn(messageProperties)
         whenever(message.body).thenReturn(eventByte)
-        whenever(ipReleaseEventHandler.handle(releasedIpDto)).thenReturn(releasedIpDto.toMono())
+        whenever(ipReleaseEventHandler.handle(releasedIpDto, Unit)).thenReturn(Unit.toMono())
 
         target.handle(message)
-        verify(ipReleaseEventHandler, times(1)).handle(any())
+        verify(ipReleaseEventHandler, times(1)).handle(releasedIpDto, Unit)
         verify(eventPublishService, never()).publish(any(), any())
     }
 
@@ -76,7 +76,7 @@ class IpReleasedEventListenerTest {
         whenever(message.body).thenReturn(eventByte)
 
         target.handle(message)
-        verify(ipReleaseEventHandler, never()).handle(any())
+        verify(ipReleaseEventHandler, never()).handle(any(), any())
         verify(eventPublishService, never()).publish(any(), any())
     }
 
@@ -89,7 +89,7 @@ class IpReleasedEventListenerTest {
         whenever(message.body).thenReturn(eventStr.toByteArray())
 
         target.handle(message)
-        verify(ipReleaseEventHandler, never()).handle(any())
+        verify(ipReleaseEventHandler, never()).handle(any(), any())
         verify(eventPublishService, times(1)).publish(
             Error.WRONG_PAYLOAD.routingKey,
             WrongPayloadError(Event.IP_RELEASED, message.body.toString())


### PR DESCRIPTION
기존 EventListener 내에 존재하던 Handling 로직을 Handler 에게 위임하여, DataParsing 만 하도록 변경하였습니다.
또한, EventHandle 로직을 추상화하였으며, 자잘한 코드 리팩터링을 수행하였습니다.