### PR TITLE
MQ 오류 전파 로직 보완

### DIFF
--- a/src/main/kotlin/com/iplease/server/ip/manage/infra/log/util/EventSubscribeLoggerUtil.kt
+++ b/src/main/kotlin/com/iplease/server/ip/manage/infra/log/util/EventSubscribeLoggerUtil.kt
@@ -5,7 +5,7 @@ import org.springframework.stereotype.Component
 
 @Component
 class EventSubscribeLoggerUtil: SimpleLoggerUtil<EventSubscribeInput, Unit>(
-    LoggerFactory.getLogger(EventPublishLoggerUtil::class.java),
+    LoggerFactory.getLogger(EventSubscribeLoggerUtil::class.java),
     "[AMQP] [이벤트 - 구독]"
 ) {
     override fun logOnStart(input: EventSubscribeInput, uuid: String) {

--- a/src/main/kotlin/com/iplease/server/ip/manage/infra/message/data/dto/WrongPayloadError.kt
+++ b/src/main/kotlin/com/iplease/server/ip/manage/infra/message/data/dto/WrongPayloadError.kt
@@ -4,8 +4,7 @@ import com.iplease.server.ip.manage.infra.message.data.ErrorData
 import com.iplease.server.ip.manage.infra.message.data.type.Event
 
 data class WrongPayloadError(
-    private val originEvent: Event,
-    val payload: String
+    private val originEvent: Event
 ): ErrorData {
     init { val originRoutingKey = originEvent.routingKey }
 }

--- a/src/main/kotlin/com/iplease/server/ip/manage/infra/message/listener/EventMessageSubscriberV2.kt
+++ b/src/main/kotlin/com/iplease/server/ip/manage/infra/message/listener/EventMessageSubscriberV2.kt
@@ -28,7 +28,7 @@ abstract class EventMessageSubscriberV2<T: Any> (
             .registerModule(JavaTimeModule())
             .toMono()
             .map{ it.readValue(message.body, type.java) }
-            .doOnError { messagePublishService.publishError(Error.WRONG_PAYLOAD, WrongPayloadError(event, "")) }
+            .doOnError { messagePublishService.publishError(Error.WRONG_PAYLOAD, WrongPayloadError(event)) }
 
     override fun subscribe(message: Message) {
         if(message.messageProperties.receivedRoutingKey != event.routingKey) return

--- a/src/test/kotlin/com/iplease/server/ip/manage/domain/assign/subscriber/IpAssignedMessageSubscriberTest.kt
+++ b/src/test/kotlin/com/iplease/server/ip/manage/domain/assign/subscriber/IpAssignedMessageSubscriberTest.kt
@@ -101,6 +101,6 @@ class IpAssignedMessageSubscriberTest {
 
         target.subscribe(message)
         verify(ipAssignedEventHandler, never()).handle(eq(assignedIpDto), any())
-        verify(messagePublishService, times(1)).publishError(Error.WRONG_PAYLOAD, WrongPayloadError(Event.IP_ASSIGNED, message.body.toString()))
+        verify(messagePublishService, times(1)).publishError(Error.WRONG_PAYLOAD, WrongPayloadError(Event.IP_ASSIGNED))
     }
 }


### PR DESCRIPTION
Payload 가 null 인 message 에 대한 처리중, Exception 이 발생하여 MessageHandling Loop 가 발생하는것을 막고자, empty error handling 로직을 추가하였습니다.